### PR TITLE
feat: use decorator to bind this

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,3 +1,18 @@
+// autobind decorator
+// target과 methodName를 사용하지 않으므로 _, _2로 선언해도 된다.
+const autobind = (_: any, _2: string, descriptor: PropertyDescriptor) => {
+    const originalMethod = descriptor.value;
+    const adjDescriptor = {
+        configurable: true,
+        get() {
+            const boundFn = originalMethod.bind(this);
+            return boundFn;
+        }
+    };
+    return adjDescriptor;
+}
+
+
 class ProjectInput {
     templateElement: HTMLTemplateElement;
     hostElement: HTMLDivElement;
@@ -32,6 +47,7 @@ class ProjectInput {
         this.attach();
     }
 
+    @autobind
     private submitHandler(event: Event) {
         event.preventDefault();
         console.log(this.titleInputElement.value);
@@ -39,7 +55,7 @@ class ProjectInput {
 
     private configure() {
         // binding을 하지 않으면 콜백함수를 호출하는 친구는 this.element이기에 submitHandler의 this는 this.element가 된다.
-        this.element.addEventListener("submit", this.submitHandler.bind(this));
+        this.element.addEventListener("submit", this.submitHandler);
     }
 
     private attach() {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -50,7 +50,7 @@
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
     // "types": [],                           /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    "esModuleInterop": true,                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
 
     /* Source Map Options */
@@ -60,7 +60,7 @@
     // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
 
     /* Experimental Options */
-    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+    "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
   },
   "exclude": [


### PR DESCRIPTION
# Decorator를 이용한 AutoBind

## 1. `autobind` 함수의 인자 구조

데코레이터 함수는 기본적으로 다음과 같은 시그니처를 가진다.

```ts
function decorator(target: any, methodName: string, descriptor: PropertyDescriptor): PropertyDescriptor | void;
```

이제 `autobind`의 인자를 보면:

```ts
const autobind = (_: any, _2: string, descriptor: PropertyDescriptor) => { ... }
```

### - `target: any` (여기서는 `_`)
데코레이터가 적용된 메서드가 속한 클래스의 프로토타입 객체다.  
하지만 `autobind`에서는 클래스의 프로토타입을 직접 다루지 않으므로 사용하지 않아 `_`로 이름을 붙였다.

### - `methodName: string` (여기서는 `_2`)
데코레이터가 적용된 메서드의 이름(예: `"submitHandler"`)이 전달된다.  
하지만 이 정보는 필요하지 않으므로 `_2`로 이름을 붙여 무시하고 있다.

### - `descriptor: PropertyDescriptor`
이것이 핵심이다!  
`descriptor`는 해당 메서드에 대한 **속성 설명 객체**로, 다음과 같은 구조를 가진다.

```ts
{
  value: function() { ... },   // 원래 메서드
  writable: true,              // 값 변경 가능 여부
  enumerable: false,           // 열거 가능 여부
  configurable: true           // 속성 변경 가능 여부
}
```

## 속성 설명 객체란??
속성 설명 객체는 객체의 속성에 대한 정의 정보를 담고 있는 객체다

속성 | 설명 | 기본값
-- | -- | --
value | 속성의 값 | undefined
writable | 값을 변경할 수 있는지 여부 (true면 변경 가능) | false
enumerable | for...in 또는 Object.keys()로 열거 가능한지 여부 | false
configurable | 속성 삭제(delete obj.prop), 속성 설명 변경 가능 여부 | false
get | 값을 가져오는 함수 (getter) | undefined
set | 값을 설정하는 함수 (setter) | undefined


### 속성 설명 객체 예제
#### 📌 (1) Object.getOwnPropertyDescriptor()로 속성 정보 확인하기
```ts
const obj = {
    name: "Alice",
    age: 25
};


console.log(Object.getOwnPropertyDescriptor(obj, "name"));
```
출력 결과:
```js
{
  value: "Alice",
  writable: true,
  enumerable: true,
  configurable: true
}
```
- `name` 속성의 값(`value`)은 `"Alice"`
- `writable: true` → 값을 변경할 수 있음 (`obj.name = "Bob"` 가능)
- `enumerable: true` → `for...in` / `Object.keys(obj)`에서 보임
- `configurable: true` → 속성 삭제 가능 (`delete obj.name` 가능)

---
#### 📌 (2) Object.defineProperty()로 속성 제어하기
```ts
const user = {};

Object.defineProperty(user, "name", {
    value: "Charlie",
    writable: false,  // 값 변경 불가
    enumerable: true, // 열거 가능
    configurable: false // 삭제 및 속성 변경 불가
});

console.log(user.name); // "Charlie"

user.name = "David"; 
console.log(user.name); // 여전히 "Charlie" (변경되지 않음)

delete user.name;
console.log(user.name); // "Charlie" (삭제되지 않음)
```
✅ 속성 설정 결과
- `writable: false` → 값 변경 불가 (`user.name = "David"` 해도 변화 없음)
- `configurable: false` → `delete user.name`을 해도 삭제되지 않음
- `enumerable: true` → `Object.keys(user)`에서 보임

---
#### 📌 (3) 데이터 속성과 접근자 속성

- **데이터 속성**: 기본적인 속성(프로퍼티)로, value, writable 등의 속성을 가짐.
- **접근자 속성**: `get`과 `set`을 이용해 속성을 가져오거나 설정할 때 특정 동작을 수행할 수 있음.
- **한 속성이 `value/writable`과 `get/set`을 동시에 가질 수 없음

```ts
const user = {
    firstName: "John",
    lastName: "Doe"
};

Object.defineProperty(user, "fullName", {
    get() {
        return `${this.firstName} ${this.lastName}`;
    },
    set(value: string) {
        const [first, last] = value.split(" ");
        this.firstName = first;
        this.lastName = last;
    },
    enumerable: true,
    configurable: true
});

console.log(user.fullName); // "John Doe"

user.fullName = "Alice Brown";
console.log(user.firstName); // "Alice"
console.log(user.lastName);  // "Brown"
```

✅ 속성 설정 결과
- `get` → `user.fullName`을 읽을 때 자동으로 `this.firstName + this.lastName` 반환
- `set` → `user.fullName = "Alice Brown"` 하면 `firstName`과 `lastName`이 자동 변경됨

이제 `descriptor`를 변경하는 이유를 보자.

---

### 2. `adjDescriptor`의 구조와 역할

```ts
const adjDescriptor = {
    configurable: true,
    get() {
        const boundFn = originalMethod.bind(this);
        return boundFn;
    }
};
```

#### 🔹 원래 방식대로 `descriptor.value`를 수정하지 않는 이유
처음에는 이렇게 해볼 수도 있다.

```ts
descriptor.value = descriptor.value.bind(this);
return descriptor;
```

하지만 이렇게 하면 **한 번만 바인딩되고, 이후에는 바뀌지 않는다**는 문제가 있다.  

#### ❌ **여기서 문제가 발생하는 이유**
- 바인딩된 함수가 프로토타입에 저장되므로, **모든 인스턴스가 같은 `this`를 사용하게 됨.**
- 다른 인스턴스에서 호출해도 `this`가 처음 바인딩된 곳을 가리킬 수 있음.

---

#### 🔹 `get()` 접근자를 사용하는 이유

`get()`을 사용하면, 해당 메서드를 **호출할 때마다 새로운 바인딩된 함수를 반환**할 수 있다.

```ts
get() {
    const boundFn = originalMethod.bind(this);
    return boundFn;
}
```

즉, `this.submitHandler`를 호출할 때마다:

1. `originalMethod`를 가져온다.
2. `originalMethod.bind(this)`를 호출하여 현재 `this`에 바인딩된 새 함수를 만든다.
3. 해당 바인딩된 함수를 반환한다.

이 방식이 가지는 장점은:

- **다양한 인스턴스에서도 올바른 `this`를 유지**할 수 있음
- **메서드가 재할당될 때마다 자동으로 `this`를 바인딩**할 수 있음

즉, `submitHandler`를 이벤트 핸들러로 전달하더라도 `this`가 변하지 않는다.

---

### 3. 전체 흐름 다시 보기

```ts
@autobind
private submitHandler(event: Event) {
    event.preventDefault();
    console.log(this.titleInputElement.value);
}
```

1. `submitHandler`가 클래스에 추가될 때, `autobind`가 실행된다.
2. `descriptor.value`에서 원래 메서드를 가져와 `originalMethod`에 저장한다.
3. `descriptor.value`를 직접 변경하는 대신, **`get()` 접근자**를 설정한다.
4. `submitHandler`가 호출될 때마다 `get()`이 실행되며:
   - `originalMethod.bind(this)`를 호출하여 새 함수 `boundFn`을 생성
   - 그 `boundFn`을 반환
5. 따라서 `this.submitHandler`를 직접 호출하든, 이벤트 리스너에 전달하든 `this`가 항상 올바르게 유지된다.

---

### 4. 정리

- `target`과 `methodName`은 필요 없으므로 `_`, `_2`로 무시.
- `descriptor`는 메서드의 속성을 정의하는 객체이므로 이를 조작.
- `descriptor.value`를 직접 수정하지 않고 `get()` 접근자를 사용하여, **항상 바인딩된 새로운 함수**를 반환하도록 설정.
- 이를 통해 `this`가 자동으로 올바르게 유지됨.
